### PR TITLE
Add support for user-provided relationship free float in Longest Path…

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -92,6 +92,12 @@
             "description": "Lag or lead time (negative lag) for relationship in work days"
         },
         {
+            "name": "relationshipFreeFloat",
+            "kind": "Measure",
+            "displayName": "Relationship Free Float",
+            "description": "Pre-calculated free float for each relationship (optional - will calculate if not provided)"
+        },
+        {
             "name": "tooltip",
             "kind": "Grouping",
             "displayName": "Tooltip",
@@ -284,6 +290,7 @@
                         { "bind": { "to": "predecessorId" } },
                         { "bind": { "to": "relationshipType" } },
                         { "bind": { "to": "relationshipLag" } },
+                        { "bind": { "to": "relationshipFreeFloat" } },
                         { "bind": { "to": "tooltip" } }
                     ],
                     "dataReductionAlgorithm": { "top": { "count": 60000 } }


### PR DESCRIPTION
… mode

Changes:
- Added relationshipFreeFloat data role to capabilities.json
- Updated dataViewMappings to include relationshipFreeFloat field
- Modified relationship parsing to extract free float from dataset
- Updated identifyDrivingRelationships() to use provided free float when available
- Falls back to calculated relationship float if not provided

This allows users to provide pre-calculated relationship free float values from their P6 dataset, which will be used directly in driving relationship identification instead of being calculated from dates. If the field is not provided, the visual maintains backward compatibility by calculating the relationship float as before.