### PR TITLE
Add WBS grouping feature with expand/collapse functionality

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -108,6 +108,30 @@
             "kind": "Grouping",
             "displayName": "Legend",
             "description": "Categorical field to color tasks (e.g., WBS, Department, Phase)"
+        },
+        {
+            "name": "wbsLevel2",
+            "kind": "Grouping",
+            "displayName": "WBS Level 2",
+            "description": "Work Breakdown Structure Level 2 grouping field"
+        },
+        {
+            "name": "wbsLevel3",
+            "kind": "Grouping",
+            "displayName": "WBS Level 3",
+            "description": "Work Breakdown Structure Level 3 grouping field"
+        },
+        {
+            "name": "wbsLevel4",
+            "kind": "Grouping",
+            "displayName": "WBS Level 4",
+            "description": "Work Breakdown Structure Level 4 grouping field"
+        },
+        {
+            "name": "wbsLevel5",
+            "kind": "Grouping",
+            "displayName": "WBS Level 5",
+            "description": "Work Breakdown Structure Level 5 grouping field"
         }
     ],
     "objects": {
@@ -346,6 +370,42 @@
                 }
             }
         },
+        "wbsGrouping": {
+            "displayName": "WBS Grouping",
+            "description": "Work Breakdown Structure grouping settings",
+            "properties": {
+                "enableWbsGrouping": {
+                    "displayName": "Enable WBS Grouping",
+                    "description": "Group tasks by WBS hierarchy",
+                    "type": { "bool": true }
+                },
+                "defaultExpanded": {
+                    "displayName": "Default Expanded",
+                    "description": "Expand all WBS groups by default",
+                    "type": { "bool": true }
+                },
+                "showGroupSummary": {
+                    "displayName": "Show Group Summary Bar",
+                    "description": "Display a summary bar for each WBS group",
+                    "type": { "bool": true }
+                },
+                "groupHeaderColor": {
+                    "displayName": "Group Header Background",
+                    "description": "Background color for WBS group headers",
+                    "type": { "fill": { "solid": { "color": true } } }
+                },
+                "groupSummaryColor": {
+                    "displayName": "Group Summary Bar Color",
+                    "description": "Color for WBS group summary bars",
+                    "type": { "fill": { "solid": { "color": true } } }
+                },
+                "indentPerLevel": {
+                    "displayName": "Indent Per Level (px)",
+                    "description": "Indentation for each WBS level",
+                    "type": { "numeric": true }
+                }
+            }
+        },
         "legendColors": {
             "displayName": "Legend Colors",
             "description": "Customize colors for legend categories",
@@ -395,7 +455,11 @@
                         { "bind": { "to": "relationshipLag" } },
                         { "bind": { "to": "relationshipFreeFloat" } },
                         { "bind": { "to": "tooltip" } },
-                        { "bind": { "to": "legend" } }
+                        { "bind": { "to": "legend" } },
+                        { "bind": { "to": "wbsLevel2" } },
+                        { "bind": { "to": "wbsLevel3" } },
+                        { "bind": { "to": "wbsLevel4" } },
+                        { "bind": { "to": "wbsLevel5" } }
                     ],
                     "dataReductionAlgorithm": { "top": { "count": 60000 } }
                 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -393,6 +393,66 @@ class LegendCard extends Card {
     slices: Slice[] = [this.show, this.position, this.fontSize, this.showTitle, this.titleText, this.sortOrder];
 }
 
+class WBSGroupingCard extends Card {
+    name: string = "wbsGrouping";
+    displayName: string = "WBS Grouping";
+
+    enableWbsGrouping = new ToggleSwitch({
+        name: "enableWbsGrouping",
+        displayName: "Enable WBS Grouping",
+        description: "Group tasks by WBS hierarchy",
+        value: false
+    });
+
+    defaultExpanded = new ToggleSwitch({
+        name: "defaultExpanded",
+        displayName: "Default Expanded",
+        description: "Expand all WBS groups by default",
+        value: true
+    });
+
+    showGroupSummary = new ToggleSwitch({
+        name: "showGroupSummary",
+        displayName: "Show Group Summary Bar",
+        description: "Display a summary bar for each WBS group",
+        value: true
+    });
+
+    groupHeaderColor = new ColorPicker({
+        name: "groupHeaderColor",
+        displayName: "Group Header Background",
+        description: "Background color for WBS group headers",
+        value: { value: "#F0F0F0" }
+    });
+
+    groupSummaryColor = new ColorPicker({
+        name: "groupSummaryColor",
+        displayName: "Group Summary Bar Color",
+        description: "Color for WBS group summary bars",
+        value: { value: "#808080" }
+    });
+
+    indentPerLevel = new NumUpDown({
+        name: "indentPerLevel",
+        displayName: "Indent Per Level (px)",
+        description: "Indentation for each WBS level",
+        value: 20,
+        options: {
+            minValue: { type: powerbi.visuals.ValidatorType.Min, value: 0 },
+            maxValue: { type: powerbi.visuals.ValidatorType.Max, value: 50 }
+        }
+    });
+
+    slices: Slice[] = [
+        this.enableWbsGrouping,
+        this.defaultExpanded,
+        this.showGroupSummary,
+        this.groupHeaderColor,
+        this.groupSummaryColor,
+        this.indentPerLevel
+    ];
+}
+
 class LegendColorsCard extends Card {
     name: string = "legendColors";
     displayName: string = "Legend Colors";
@@ -466,6 +526,7 @@ export class VisualSettings extends Model {
     criticalityMode = new CriticalityModeCard();
     drivingPathSelection = new DrivingPathSelectionCard();
     taskSelection = new TaskSelectionCard();
+    wbsGrouping = new WBSGroupingCard();
     legend = new LegendCard();
     legendColors = new LegendColorsCard();
     persistedState = new PersistedStateCard();
@@ -483,6 +544,7 @@ export class VisualSettings extends Model {
         this.criticalityMode,
         this.drivingPathSelection,
         this.taskSelection,
+        this.wbsGrouping,
         this.legend,
         this.legendColors,
         this.persistedState


### PR DESCRIPTION
- Add WBS Level 2-5 data roles in capabilities.json for hierarchical grouping
- Create WBSGroup interface for managing WBS hierarchy
- Add WBS grouping settings card with configurable options:
  - Enable/disable WBS grouping
  - Default expanded state
  - Show group summary bars
  - Customizable header and summary colors
  - Indent per level setting
- Implement WBS data extraction from linked tables
- Build hierarchical WBS structure with parent-child relationships
- Add expand/collapse toggle for WBS groups with click handlers
- Calculate summary dates (earliest start, latest finish) for groups
- Display task count when groups are collapsed
- Apply indentation to task labels based on WBS level
- Filter tasks based on group expansion state