### PR TITLE
Enhance WBS grouping functionality

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -443,9 +443,25 @@ class WBSGroupingCard extends Card {
         }
     });
 
+    hideEmptyGroups = new ToggleSwitch({
+        name: "hideEmptyGroups",
+        displayName: "Hide Empty Groups",
+        description: "Hide WBS groups that have no visible/filtered tasks",
+        value: true
+    });
+
+    expandCollapseAll = new ToggleSwitch({
+        name: "expandCollapseAll",
+        displayName: "Expand All Groups",
+        description: "Toggle to expand or collapse all WBS groups at once",
+        value: true
+    });
+
     slices: Slice[] = [
         this.enableWbsGrouping,
         this.defaultExpanded,
+        this.expandCollapseAll,
+        this.hideEmptyGroups,
         this.showGroupSummary,
         this.groupHeaderColor,
         this.groupSummaryColor,


### PR DESCRIPTION
- Hide WBS groups with no visible/filtered tasks (configurable via hideEmptyGroups setting)
- Add expand/collapse all toggle for bulk WBS group management
- Sort WBS groups by earliest start date for logical chronological ordering
- Groups without matching filtered tasks are now excluded from the visual