### PR TITLE
Fix WBS toggle flickering after scroll stops

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -8437,6 +8437,14 @@ private toggleWbsGroupExpansion(groupId: string): void {
     const group = this.wbsGroupMap.get(groupId);
     if (!group) return;
 
+    // CRITICAL: Clear any pending scroll throttle timeout to prevent it from
+    // interfering with the WBS toggle update. Without this, drawVisualElements()
+    // would skip rendering if a scroll just happened (scrollThrottleTimeout !== null)
+    if (this.scrollThrottleTimeout) {
+        clearTimeout(this.scrollThrottleTimeout);
+        this.scrollThrottleTimeout = null;
+    }
+
     // Before toggling, capture the group's visual position (position relative to viewport)
     // so we can restore it after re-render
     if (this.scrollableContainer?.node() && group.yOrder !== undefined) {


### PR DESCRIPTION
Issue: When user scrolled and then immediately expanded a WBS section, flickering occurred because:

1. Scroll sets scrollThrottleTimeout (50ms delay)
2. User clicks WBS expand before timeout fires
3. drawVisualElements() checks scrollThrottleTimeout !== null
4. Since timeout is still pending, drawVisualElements() returns early!
5. 50ms later, handleScroll() fires and causes delayed redraw

Fix: Clear the scroll throttle timeout at the start of toggleWbsGroupExpansion() to ensure drawVisualElements() doesn't skip rendering.