### PR TITLE
251211 Interactive behavior bug fixes

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -321,7 +321,8 @@
             "properties": {
                 "selectedTaskId": { "type": { "text": true } },
                 "floatThreshold": { "type": { "numeric": true } },
-                "traceMode": { "type": { "text": true } }
+                "traceMode": { "type": { "text": true } },
+                "selectedLegendCategories": { "type": { "text": true } }
             }
         },
         "legend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "visual",
-  "version": "1.0.0.0",
+  "version": "2.0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "visual",
-      "version": "1.0.0.0",
+      "version": "2.0.0.0",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -22,6 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^8.8.0",
         "eslint": "^9.11.1",
         "eslint-plugin-powerbi-visuals": "^1.0.0",
+        "ts-loader": "^9.5.4",
         "typescript": "5.5.4",
         "worker-loader": "^3.0.8"
       }
@@ -2309,7 +2310,6 @@
       "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -2880,8 +2880,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3935,7 +3934,6 @@
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -4032,6 +4030,37 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-loader": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
+      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^8.8.0",
     "eslint": "^9.11.1",
     "eslint-plugin-powerbi-visuals": "^1.0.0",
+    "ts-loader": "^9.5.4",
     "typescript": "5.5.4",
     "worker-loader": "^3.0.8"
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -590,7 +590,15 @@ class PersistedStateCard extends Card {
         placeholder: "",
         visible: false
     });
-    slices: Slice[] = [this.selectedTaskId, this.floatThreshold, this.traceMode];
+    // BUG-006 FIX: Store selected legend categories as comma-separated string
+    selectedLegendCategories = new TextInput({
+        name: "selectedLegendCategories",
+        displayName: "",
+        value: "",
+        placeholder: "",
+        visible: false
+    });
+    slices: Slice[] = [this.selectedTaskId, this.floatThreshold, this.traceMode, this.selectedLegendCategories];
 }
 
 export class VisualSettings extends Model {


### PR DESCRIPTION
- BUG-001: Preserve scroll on Show All/Critical toggle
- BUG-002: Preserve scroll on criticality mode toggle
- BUG-004: Preserve scroll on trace mode toggle
- BUG-005: Preserve scroll on legend category toggle
- BUG-006: Persist legend selection state across sessions
- BUG-007: Preserve manual WBS expansion states on global toggle
- BUG-008: Prevent race condition during margin drag
- BUG-011: Reduce flicker on Canvas/SVG mode switch
- BUG-012: Ensure scroll handler restored on update error

Added captureScrollPosition() helper for centralized scroll preservation. Added isMarginDragging flag to block Power BI updates during drag. Added wbsManuallyToggledGroups Set to track per-group manual overrides. Added selectedLegendCategories persistence to capabilities and settings.