### PR TITLE
Fix label collision bug when toggling WBS on/off

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -5318,6 +5318,11 @@ private redrawVisibleTasks(): void {
     if (this.labelGridLayer) {
         this.labelGridLayer.selectAll(".label-grid-line").remove();
     }
+    // FIX #6: Clear task label layer before redrawing to prevent label collisions
+    // This ensures old labels don't overlap with WBS headers or persist after toggles
+    if (this.taskLabelLayer) {
+        this.taskLabelLayer.selectAll("*").remove();
+    }
 
     // MODIFICATION: Prepare for Gridline redraw
     const showHorzGridLines = this.settings.gridLines.showGridLines.value;


### PR DESCRIPTION
ISSUE:
When WBS grouping is toggled OFF then ON, task labels render on top of WBS group headers, and some labels disappear entirely. This causes visual corruption with overlapping text.

ROOT CAUSE:
The redrawVisibleTasks() method was clearing wbsGroupLayer and labelGridLayer before redrawing, but was NOT clearing taskLabelLayer. This caused old labels to persist in the DOM while new labels were added, resulting in:
1. Label accumulation/collision (old + new labels stacked)
2. Labels rendering over WBS group headers
3. Missing labels when D3 data join failed to match tasks

FIX #6: Clear Task Label Layer Before Redrawing
- Added taskLabelLayer.selectAll("*").remove() in redrawVisibleTasks() (line 5323)
- Ensures clean slate before drawing new labels
- Prevents label accumulation across toggle operations
- Mirrors the cleanup pattern used for other layers (wbsGroupLayer, labelGridLayer)

VERIFICATION:
All render paths now properly clear taskLabelLayer:
- forceCanvasRefresh() - line 1069 (already existed)
- handleViewportOnlyUpdate() - line 4629 (already existed)
- redrawVisibleTasks() - line 5324 (newly added)

This fix complements the 5 previous fixes for toggle rendering corruption.

Testing: Toggle WBS OFF → ON → labels should render cleanly without overlap