### PR TITLE
Fix margin resizer drag lag when WBS grouping is enabled

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -3933,12 +3933,12 @@ export class Visual implements IVisual {
             .attr("height", chartHeight + 100);
 
         // 4. Clear layers for redraw (skip arrowLayer — arrows are deferred to drag end)
+        // WBS group headers and task labels use D3 enter/update/exit data binding,
+        // so skip clearing them to allow element reuse during drag.
         this.gridLayer?.selectAll("*").remove();
         this.taskLayer?.selectAll("*").remove();
-        this.taskLabelLayer?.selectAll("*").remove();
         this.labelGridLayer?.selectAll("*").remove();
         this.headerGridLayer?.selectAll("*").remove();
-        this.wbsGroupLayer?.selectAll('.wbs-group-header').remove();
 
         // 5. Redraw all visual elements except arrows
         const visibleTasks = this.getVisibleTasks();
@@ -3967,7 +3967,7 @@ export class Visual implements IVisual {
         this.drawColumnHeaders(this.headerHeight, effectiveMargin);
 
         // WBS group headers (suppress text collisions to prevent jitter during drag)
-        this.drawWbsGroupHeaders(this.xScale, this.yScale, chartWidth, taskHeight, effectiveMargin, undefined, undefined);
+        this.drawWbsGroupHeaders(this.xScale, this.yScale, chartWidth, taskHeight, effectiveMargin, this.viewportStartIndex, this.viewportEndIndex);
 
         // Task bars + milestones
         this.drawTasks(


### PR DESCRIPTION
Same root cause as the scroll lag: handleMarginDragUpdate() was unconditionally clearing WBS group headers and task labels before every drag frame, defeating D3 data binding. It also rendered all WBS groups instead of just those in the viewport.

- Remove redundant wbsGroupLayer and taskLabelLayer clears from handleMarginDragUpdate to allow D3 enter/update/exit element reuse
- Pass viewportStartIndex/viewportEndIndex to drawWbsGroupHeaders to limit rendering scope to visible groups only

https://claude.ai/code/session_01A3BoKSgadv6d2BCMBmFteb