### PR TITLE
Restore task label clear in drag handler for live text wrapping

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -3933,10 +3933,13 @@ export class Visual implements IVisual {
             .attr("height", chartHeight + 100);
 
         // 4. Clear layers for redraw (skip arrowLayer — arrows are deferred to drag end)
-        // WBS group headers and task labels use D3 enter/update/exit data binding,
+        // WBS group headers use D3 enter/update/exit data binding in drawWbsGroupHeaders(),
         // so skip clearing them to allow element reuse during drag.
+        // Task labels must be cleared here because the available width changes on every
+        // drag frame, requiring full text re-wrapping.
         this.gridLayer?.selectAll("*").remove();
         this.taskLayer?.selectAll("*").remove();
+        this.taskLabelLayer?.selectAll("*").remove();
         this.labelGridLayer?.selectAll("*").remove();
         this.headerGridLayer?.selectAll("*").remove();
 


### PR DESCRIPTION
The previous commit incorrectly removed the taskLabelLayer clear from handleMarginDragUpdate(). Unlike scrolling (where margin width stays constant and D3 data binding can reuse groups), dragging changes the available width on every frame — task names must fully re-wrap to fit the new column width. Restoring the clear ensures live label updates during drag while still keeping the WBS group header D3 reuse optimization.

https://claude.ai/code/session_01A3BoKSgadv6d2BCMBmFteb